### PR TITLE
Fix for #43 drop outdated viglink integration

### DIFF
--- a/_includes/footer/footer-widget-col3.html
+++ b/_includes/footer/footer-widget-col3.html
@@ -8,13 +8,3 @@
     </amp-img>
   </a>
 </div>
-<!-- Affiliate Disclouse -->
-<div id="vig-disclose">
-  <a href="https://www.viglink.com/legal/consumer-disclosure/" data-vars-event-label="Viglink Badge"
-    aria-label="Disclouse of Sovrn //Commerce Affiliate Program - link opens in a new tab"
-    rel="noopener noreferrer" target="_blank">
-    <amp-img src="https://www.viglink.com/images/badges/120x60.png" width="120" height="60"
-      alt="Links monetized by VigLink" title="Opens in New Tab" style="width:120px;height:60px;margin:5px;">
-    </amp-img>
-  </a>
-</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -331,16 +331,6 @@
     {%- endif -%}
 
     <amp-image-lightbox id="lightbox1" layout="nodisplay" data-close-button-aria-label="Close" hidden="hidden"></amp-image-lightbox>
-    <amp-link-rewriter layout="nodisplay">
-      <script type="application/json">
-        {
-          "output": "https://redirect.viglink.com?key=${apiKey}&u=${href}&type=ap&loc=SOURCE_URL&ref=DOCUMENT_REFERRER",
-          "vars": {
-            "apiKey": "56a8cde8bc46ec169ed23320c0e35c68"
-          }
-        }
-      </script>
-    </amp-link-rewriter>
 
   </body>
 </html>

--- a/_sass/old_files/main.scss
+++ b/_sass/old_files/main.scss
@@ -191,10 +191,3 @@ ul.tags.rounded-tags {
 	color: #ffffff !important;
 }
 /* END Buy Me A Coffee */
-
-/* Viglink */
-a.vglnk {
-  border-bottom:2px dashed gray;
-  box-shadow: unset;
-}
-/* END Viglink */


### PR DESCRIPTION
Fixes for #43 

- [x] Remove CSS for Viglink from archived `main.scss`
- [x] Remove script that redirect links to viglink from default page layout
- [x] Remove Viglink disclouse badge from footer section
