### PR TITLE
⚰ Update to Google Analytics 4 and Cleanup Deprecated Configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # AMP Affiliately Jekyll Theme Changelog
 
+<!-- markdownlint-disable MD024 -->
+
 ## v3.1.0 (2024-11-05)
 
 ### ✨ Features
@@ -14,6 +16,23 @@
 - Created a new documentation page, "Footer Configuration," providing detailed guidance on customizing footer columns and options.
 - Updated the "Config Guide" page to include the latest information about footer options, ensuring comprehensive user instructions.
 
+## v3.0.1 (2024-11-15)
+
+### ♻️ Refactors
+
+- Refactored conditional check for `site.ga4` in `postproc-content.html`.
+- Updated example configuration files to use GA4 Measurement ID.
+
+### 🗑️ Removed/Deprecated
+
+- Removed AddThis share buttons and related configurations from `_includes/blocks/share-buttons.html`, `_layouts/default.html`, `_layouts/post-left-sidebar.html`, and `_layouts/post.html`.
+- Removed `addthis_inline_share_toolbox` styles from `_sass/old_files/main.scss`.
+- Removed outdated Google Analytics configurations in `youtube.html` and `default.html`.
+
+### 📝 Documentation
+
+- Updated README and Front Matter Guide to reflect the removal of discontinued AMP AddThis components and services.
+- Updated README and Config Guide to remove deprecated Google Analytics and highlight Google Analytics 4 (GA4).
 
 ## v3.0.0 (2024-09-29)
 
@@ -34,8 +53,6 @@
 - Removed deprecated `gulp-minify-inline` task from `gulpfile.mjs`
 - Removed deprecated `css2scss` task and `@gecka/styleflux` from the gulp pipeline.
 - Removed overrides for `gulp` dependencies: `glob-watcher`, `minimatch`, `semver`, `set-value`, and `vinyl-fs`.
-- Removed AddThis share buttons and related configurations from `_includes/blocks/share-buttons.html`, `_layouts/default.html`, `_layouts/post-left-sidebar.html`, and `_layouts/post.html`.
-- Removed `addthis_inline_share_toolbox` styles from `_sass/old_files/main.scss`.
 
 ### 💚 CI/CD
 
@@ -57,7 +74,6 @@
 - Updated the status badge for CodeQL action.
 - Updated the status badge for Jekyll build workflow.
 - Updated README to document the new Jekyll build workflow. Included details on the new workflow steps and configuration.
-- Updated README.md and Front Matter Guide to reflect the removal of discontinued AMP AddThis components and services.
 
 ## v2.9.1 (2024-03-12)
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Read the procedures in the [Config Guide](https://chriskyfung.github.io/amp-affi
 
 - Read **Google Services** in the [Config Guide](https://chriskyfung.github.io//amp-affiliately-jekyll-theme/config-guide/#-google-services) ↗. For the following:
 
-  - Google Analytics
+  - Google Analytics 4
   - Google Adsense
-  - Google Custom Search Engine
   - Google Tag Manager
+  - Google Custom Search Engine
 
 #### Disqus Comments in AMP 💬
 

--- a/_config-examples/project-page/_config.yml
+++ b/_config-examples/project-page/_config.yml
@@ -54,7 +54,7 @@ amp_disqus:
 cse_id: 011006674894885990812:tjln7k0nyjx 
 
 # Analytics
-google_analytics: 'UA-72575541-9' # Google Analytics Tracking ID
+ga4: 'G-HP4LN87NJE' # Google Analytics 4 Measurement ID
 gtm: 'GTM-WQMQK3X' # Google Tag Manager ID
 
 # Google Ads

--- a/_config-examples/user-page/_config.yml
+++ b/_config-examples/user-page/_config.yml
@@ -28,7 +28,7 @@ amp_disqus:
 cse_id: 011006674894885990812:tjln7k0nyjx 
 
 # Analytics
-google_analytics: 'UA-72575541-9' # Google Analytics Tracking ID
+ga4: 'G-HP4LN87NJE' # Google Analytics 4 Measurement ID
 gtm: 'GTM-WQMQK3X' # Google Tag Manager ID
 
 # Google Ads

--- a/_includes/blocks/postproc-content.html
+++ b/_includes/blocks/postproc-content.html
@@ -1,9 +1,9 @@
 {%- comment -%}
 Modify every link with an external URL with the followings:
-- If `site.google_analytics` or `or site.ga4` is configured, add the attribute `data-vars-event-label` to the anchor tag for using AMP Google Analytics to track outbound link events
+- If `site.ga4` is configured, add the attribute `data-vars-event-label` to the anchor tag for using Google Analytics 4 for AMP to track outbound link events
 - If `site.target_blank` is configured, add rel="noopener noreferrer" and target="_blank" to the anchor tag
 {%- endcomment -%}
-{%- if site.google_analytics or site.ga4 or site.target_blank == true -%}
+{%- if site.ga4 or site.target_blank == true -%}
   {%- assign splited_by_a = page.content | split: '<a ' -%}
   {%- assign modified_content_1 = splited_by_a | first -%}
   {% for splited_a_part in splited_by_a offset:1 %}
@@ -18,7 +18,7 @@ Modify every link with an external URL with the followings:
         {%- if a_tag_lastchar == '>' -%}
         {%- assign a_inner = a_inner | append: '>' -%}
         {%- endif -%}
-        {%- if site.google_analytics or site.ga4 -%}
+        {%- if site.ga4 -%}
           {%- assign event_label = 'data-vars-event-label="' | append: a_href | append: '" ' -%}
         {%- endif -%}
         {%- if site.target_blank == true -%}

--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -18,59 +18,6 @@
 {% capture label %}youtu.be/{{ include.id }}{% endcapture %}
 {%- endif -%}
 
-{%- if site.google_analytics -%}
-{{ include.indent }}<amp-analytics type="gtag" data-credentials="include"
-    {%- if site.consent == true %}
-      data-block-on-consent-purposes="analytics"
-    {% endif -%}
-  >
-  <script type="application/json">
-    {
-      "vars" : {
-        "gtag_id": "{{ site.google_analytics }}",
-        "config" : {
-          "{{ site.google_analytics }}": { "groups": "default" }
-        }
-      },
-      "triggers": {
-        "videoPlay": {
-          "on": "video-play",
-          "request": "event",
-          "selector": "amp-youtube[data-videoid='{{ include.id }}']",
-          "vars": {
-            "event_category": "AMP YouTube player (client-side)",
-            "event_name": "Video Started",
-            "event_label": "{{ label }}",
-            "method": "Google"
-          }
-        },
-        "videoPause": {
-          "on": "video-pause",
-          "request": "event",
-          "selector": "amp-youtube[data-videoid='{{ include.id }}']",
-          "vars": {
-            "event_category": "AMP YouTube player (client-side)",
-            "event_name": "Video Paused",
-            "event_label": "{{ label }}",
-            "method": "Google"
-          }
-        },
-        "videoEnded": {
-          "on": "video-ended",
-          "request": "event",
-          "selector": "amp-youtube[data-videoid='{{ include.id }}']",
-          "vars": {
-            "event_name": "Video Ended",
-            "event_category": "AMP YouTube player (client-side)",
-            "event_label": "{{ label }}",
-            "method": "Google"
-          }
-        }
-      }
-    }
-  </script>
-  {{ include.indent }}</amp-analytics>
-{%- endif -%}
 {%- if site.ga4 -%}
 {{ include.indent }}<amp-analytics type="gtag" data-credentials="include"
     {%- if site.consent == true %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -268,38 +268,6 @@
       <!-- End Footer -->
     </div><!-- /.site-content -->
 
-    {%- if site.google_analytics -%}
-    <!-- Configure analytics to use gtag -->
-    <amp-analytics type="gtag" data-credentials="include"
-      {%- if site.consent == true %}
-        data-block-on-consent-purposes="analytics"
-      {% endif -%}
-      style="width:1px;height:1px;">
-      <script type="application/json">
-        {
-          "vars": {
-            "gtag_id": "{{ site.google_analytics }}",
-            "config": {
-              "{{ site.google_analytics }}": { "groups": "default" }
-            }
-          },
-          "triggers": {
-            "trackAnchorClicks": {
-              "selector": "a:not([href^='{{ site.url }}'])",
-              "on": "click",
-              "request": "event",
-              "vars": {
-                "event_category": "External Link",
-                "event_name": "${eventLabel}",
-                "event_label": "{{ page.url }}",
-                "method": "Google"
-              }
-            }
-          }
-        }
-      </script>
-    </amp-analytics>
-    {%- endif -%}
     {%- if site.ga4 -%}
     <amp-analytics type="gtag" data-credentials="include">
       <script type="application/json">

--- a/_posts/2021-08-02-config-guide.md
+++ b/_posts/2021-08-02-config-guide.md
@@ -323,13 +323,11 @@ defaults:
 
 |          Attribute | Description                                                                                                             |
 | -----------------: | ----------------------------------------------------------------------------------------------------------------------- |
-| `google_analytics` | <span>Deprecated</span>{:.badge.badge-default}<br> Your (`UA-`) Tracking ID. 💡 [Find your Google Analytics ID]           |
 |              `ga4` | <span>v2.6.1</span>{:.badge.badge-success}<br> Your (`G-`{:plaintext} ) Measurement ID 💡. [Find your GA4 Measurement ID] |
 
-[Find your Google Analytics ID]: https://support.google.com/analytics/answer/1008080#trackingID "Set up the Analytics global site tag - Analytics Help"
 [Find your GA4 Measurement ID]: https://support.google.com/analytics/answer/12270356 "\[GA4\] Measurement ID - Analytics Help"
 
-- When `google_analytics` is configured, an attribute called `data-vars-event-label` will be added to every `<a>` tag that links to an external URL by the post-processing of posts' content.
+- When `ga4` is configured, an attribute called `data-vars-event-label` will be added to every `<a>` tag that links to an external URL by the post-processing of posts' content.
 
 ##### <i class="fab fa-searchengin fa-fw"></i> Google Custom Search Engine (CSE)
 

--- a/_posts/2021-08-15-postprocessing.md
+++ b/_posts/2021-08-15-postprocessing.md
@@ -82,7 +82,7 @@ proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 ## Link Modifier
 
-To enable outbound link tracking with Google Analytics in AMP, you need to insert a `data-vars-event-label` attribute to external links.
+To enable outbound link tracking with Google Analytics 4 for AMP, you need to insert a `data-vars-event-label` attribute to external links.
 
 Starting from <span class="badge badge-success">v2.0</span>, this theme replace the non-whitelist `jekyll-target-blank.rb` plugin with pure Liquid templating language to modify the links.
 


### PR DESCRIPTION
This Pull Request introduces updates to the documentation and refactors the configuration files to support Google Analytics 4 (GA4), addressing deprecated configurations and improving conditional logic.

### Changes
1. **Documentation Updates for Google Analytics 4:**
   - Updated README to refer to Google Analytics 4.
   - Revised `config-guide.md` to remove references to the deprecated Google Analytics and emphasize GA4.
   - Corrected post-processing instructions to reflect the use of Google Analytics 4.
   - Updated CHANGLOG to reflect the changes.

2. **Refactor Analytics Configuration:**
   - Corrected the conditional check for `site.ga4` in `postproc-content.html`.
   - Removed outdated Google Analytics configuration in `youtube.html`.
   - Removed outdated Google Analytics configuration in `default.html`.

3. **Configuration Cleanup:**
   - Updated example files to use GA4 Measurement ID.

### Context
These updates aim to modernize the analytics tracking by transitioning fully to Google Analytics 4 and removing legacy configurations. The documentation has been updated to ensure clarity and provide accurate guidance on using GA4.

### Issues Fixed
- Fixes #57: This Pull Request addresses the migration to GA4 and removes deprecated Google Analytics configurations.