### PR TITLE
🔧 Chore: Update VS Code Settings and Jekyll Scripts for Enhanced Development Workflow

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,7 +9,6 @@
     "piotrpalarz.vscode-gitignore-generator",
     "sissel.shopify-liquid",
     "jack89ita.copy-filename",
-    "dedsec727.jekyll-run",
     "thekalinga.bootstrap4-vscode",
     "kisstkondoros.vscode-gutter-preview",
     "tchayen.markdown-links",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,8 @@
     "baseUri": "/amp-affiliately-jekyll-theme",
     "proxyUri": "http://127.0.0.1:5500/_site"
   },
-  "frontMatter.framework.startCommand": "bundle exec jekyll serve",
+  "frontMatter.framework.id": "jekyll",
+  "frontMatter.framework.startCommand": "bundle exec jekyll serve --trace --livereload",
   "frontMatter.preview.host": "http://127.0.0.1:4000/amp-affiliately-jekyll-theme/",
   "git-graph.customBranchGlobPatterns": [
     {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,5 +39,10 @@
     "--glob=remotes/origin/[^g][^h]*[^s]",
     "--glob=stash",
     "--glob=tags/*"
-  ]
+  ],
+  "markdownlint.config": {
+    "MD046": {
+      "style": "fenced"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "3.0.0",
   "scripts": {
     "convert:css2scss": "bash ./css_to_scss.sh",
-    "jekyll": "bundle exec jekyll serve",
-    "jekyll:trace": "bundle exec jekyll serve --trace",
+    "jekyll": "bundle exec jekyll serve --livereload",
+    "jekyll:trace": "bundle exec jekyll serve --trace --livereload",
     "build": "bundle exec jekyll build && gulp build",
     "test": "npx gulp validate",
     "watch": "npx gulp"


### PR DESCRIPTION
This Pull Request includes several updates to the VS Code settings and Jekyll scripts aimed at improving the development workflow. The changes include configuring the frontMatter extension, adjusting markdownlint rules, updating Jekyll scripts for live reload, and cleaning up recommended extensions.

## Changes

1. **VS Code Settings:**
   - Configured `jekyll` as the framework in the frontMatter extension settings:
     - Ensure the `frontMatter.framework.id` is set to `jekyll` for proper functionality.
   - Enhanced the start command to support improved debugging and live reloading:
     - Added `--trace --livereload` to the start command for better development experience.

2. **Markdownlint Configuration:**
   - Configured the `MD046` rule to use the `fenced` style for code blocks:
     - This style is preferred over the indented style for its consistency, readability, and compatibility with other markdown parsers.

3. **Jekyll Scripts:**
   - Added `--livereload` flag to Jekyll scripts to enhance live reloading:
     - Updated `jekyll` and `jekyll:trace` scripts to include `--livereload` for a smoother development experience.

4. **VS Code Extension Recommendations:**
   - Removed the `dedsec727.jekyll-run` extension from the recommended list in `.vscode/extensions.json`.

### Context
These changes aim to enhance the development workflow by improving debugging, live reloading, and maintaining high-quality markdown documentation. The updates ensure that the development environment is well-configured and consistent.

Please review the changes and provide feedback or approval. Your insights are invaluable to ensure these updates meet our development standards.