### PR TITLE
🔧 Fix GA4 Configuration Logic, Enhance Conditional Handling, and Add Non-Personalized Ads Fallback

### DIFF
--- a/_includes/blocks/ad-before-content.html
+++ b/_includes/blocks/ad-before-content.html
@@ -3,6 +3,7 @@
 <amp-ad width="100vw" height="200"
     {%- if site.consent == true %}
       data-block-on-consent-purposes="advertising"
+      data-npa-on-unknown-consent=true
     {% endif -%}
     type="adsense"
     data-ad-client="{{ site.adsense.client_id }}"

--- a/_includes/blocks/ga4-config.html
+++ b/_includes/blocks/ga4-config.html
@@ -47,7 +47,8 @@
           "method": "Google",
           "link_url": "${eventLabel}",
           "outbound": true
-        }{%- if include.yt_selectors %}
+        }
+      {%- if include.yt_selectors %}
       },
       "videoPlay": {
         "on": "video-play",
@@ -110,7 +111,8 @@
           "video_provider": "youtube",
           "video_title": "${videoTitle}",
           "video_url": "${videoUrl}"
-        }{% endif %}
+        }
+      {%- endif %}
       }
     }
   }

--- a/_includes/blocks/ga4-config.html
+++ b/_includes/blocks/ga4-config.html
@@ -29,9 +29,13 @@
     "vars": {
       "gtag_id": "{{ site.ga4 }}",
       "config": {
-        "{{ site.ga4 }}": { "groups": "default" }
-      },{%- if jekyll.environment != 'production' %}
-      "debug_mode": true,{% endif %}
+        "{{ site.ga4 }}": {
+          {%- if jekyll.environment != 'production' %}
+          "debug_mode": true,
+          {%- endif %}
+          "groups": "default"
+        }
+      },
       "ampHost": "${ampdocHost}"
     },
     "triggers": {

--- a/_includes/blocks/site_content_postproc.html
+++ b/_includes/blocks/site_content_postproc.html
@@ -10,8 +10,6 @@
   Date: 2024-11-23
 {%- endcomment -%}
 
-{%- assign amp_youtube_selectors = nil -%}
-
 {%- if site.ga4 and page.amp.youtube -%}
   {%- assign segments = include.content | split: '<amp-youtube ' -%}
   {%- assign processed_head = segments[0] -%}
@@ -39,11 +37,15 @@
       {%- endif -%}
     {%- endfor -%}    
     {%- assign selectors = selectors | append: ' "amp-youtube[data-videoid=' | append: "'" | append: video_id | append: "'" | append: ']"' -%}
-    
+
   {%- endfor -%}
 
   {%- assign amp_youtube_selectors = selectors | strip | replace: ' "' , ', "' -%}    
-  
+
 {%- endif -%}
-  
-{% include blocks/ga4-config.html yt_selectors=amp_youtube_selectors %}
+
+{%- unless amp_youtube_selectors contains 'amp-youtube' -%}
+  {% include blocks/ga4-config.html %}
+{%- else -%}
+  {% include blocks/ga4-config.html yt_selectors=amp_youtube_selectors %}
+{%- endunless -%}

--- a/_includes/sidebar/custom/ad-sidebar.html
+++ b/_includes/sidebar/custom/ad-sidebar.html
@@ -5,6 +5,7 @@
   <amp-ad width="100vw" height="292"
     {%- if site.consent == true %}
       data-block-on-consent-purposes="advertising"
+      data-npa-on-unknown-consent=true
     {% endif -%}
     type="adsense"
     data-ad-client="{{ site.adsense.client_id }}"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -122,6 +122,7 @@
     <amp-auto-ads type="adsense" data-ad-client="{{ site.adsense.client_id }}"
       {%- if site.consent == true %}
         data-block-on-consent-purposes="advertising"
+        data-npa-on-unknown-consent=true
       {% endif -%}
       {%- if jekyll.environment != 'production' -%}
         data-adtest="on"


### PR DESCRIPTION
This pull request addresses various issues and enhancements in the project. The changes include:

### Commits

#### ✨ feat: add non-personalized ads fallback for unknown consent status
- Added `data-npa-on-unknown-consent=true` attribute to AMP ad elements in `ad-before-content.html`, `ad-sidebar.html`, and `default.html`.
- Ensures non-personalized ads are served when user consent status is unknown.
- Enhances compliance with privacy regulations and maintains ad revenue.

**Files affected:**
- `_includes/blocks/ad-before-content.html`
- `_includes/sidebar/custom/ad-sidebar.html`
- `_layouts/default.html`

#### 🐛 fix: Correct GA4 config logic
- Ensured that `debug_mode` is correctly applied only in non-production environments.
- Moved `debug_mode` setting inside the `config` object for accurate configuration.

#### 🐛 fix: Correct conditional logic for GA4 video tracking
- Corrected the if conditions to ensure proper handling of `yt_selectors`.
- Ensured that the video settings are correctly applied for YouTube videos.
- Improved the assignment of `amp_youtube_selectors` in the `site_content_postproc.html` file.
- Enhanced readability and maintainability of the code structure.
