### PR TITLE
Update frontmatter keys for category consistency

### DIFF
--- a/.frontmatter/database/taxonomyDb.json
+++ b/.frontmatter/database/taxonomyDb.json
@@ -1,1 +1,1 @@
-{"taxonomy":{"tags":["AMP","Adsense","CMS","_config","analytics","audio","code","demo","front matter","image","markdown","plugin","styles","vscode","youtube"],"categories":[]}}
+{"taxonomy":{"tags":["AMP","Adsense","CMS","_config","analytics","audio","code","demo","front matter","image","markdown","plugin","styles","vscode","youtube"],"categories":["doc","feature","sample"]}}

--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1.2' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/_posts/2017-11-27-media.md
+++ b/_posts/2017-11-27-media.md
@@ -4,7 +4,7 @@ title: Media
 date: 2021-02-25 18:42:00 +0800
 last_modified_at: 2024-11-23 21:30 +0800
 author: chris
-category:
+categories:
   - feature
 tags:
   - image

--- a/_posts/2017-11-28-code.md
+++ b/_posts/2017-11-28-code.md
@@ -4,7 +4,7 @@ title: Code Block
 date: 2021-03-21 16:01 +0800
 last_modified_at: 2024-01-13 09:01 +0800
 author: Chris
-category:
+categories:
   - feature
 tags:
   - code

--- a/_posts/2017-11-29-sample.md
+++ b/_posts/2017-11-29-sample.md
@@ -5,7 +5,7 @@ image:
 title: Sample
 date: 2017-11-29 04:00:00
 author: Peter
-category: sample
+categories: [sample]
 custom_head: >-
   <meta name="robots" content="noindex, nofollow">
 sitemap: false

--- a/_posts/2017-11-30-style-guide.md
+++ b/_posts/2017-11-30-style-guide.md
@@ -4,7 +4,7 @@ title: Styles
 date: 2017-11-30 04:00:00
 last_modified_at: 2021-08-02 11:14 +0800
 author: Peter
-category: [feature]
+categories: [feature]
 tags: [markdown, styles, demo]
 permalink: /style-guide/
 redirect_from: [/2017/11/30/style-guide]

--- a/_posts/2021-04-02-ads-settings.md
+++ b/_posts/2021-04-02-ads-settings.md
@@ -3,7 +3,7 @@ layout: post
 title: Ads Settings
 date: 2021-04-02 11:00:00 +0800
 author: chris
-category: [doc]
+categories: [doc]
 tags: [Adsense, _config, styles, AMP]
 permalink: /ads-settings/
 image:

--- a/_posts/2021-07-20-device-look.md
+++ b/_posts/2021-07-20-device-look.md
@@ -2,7 +2,7 @@
 layout: post
 title: Responsive Web Design
 date: 2021-07-20 10:47 +0800
-category: [feature]
+categories: [feature]
 tags: [demo]
 permalink: /responsive-web-design/
 redirect_from: [/device-look/]

--- a/_posts/2021-07-30-front-matter.md
+++ b/_posts/2021-07-30-front-matter.md
@@ -3,7 +3,7 @@ layout: post
 title: Front Matter Guide
 date: 2021-07-31 12:05 +0800
 last_modified_at: 2022-02-10 22:02 +0800
-category: [doc]
+categories: [doc]
 tags: [front matter, styles, AMP]
 permalink: /front-matter-guide/
 slug: " "
@@ -38,7 +38,7 @@ slug: index.html
 title: My first blog post
 date: 2020-01-31 07:30 +0000
 last_modified_at: 2024-01-16 12:01 +0800
-category: [category1, category2]
+categories: [category1, category2]
 tags: [tag1, tag2, tag3]
 excerpt: This is the first blog post for my Jekyll site.
 ---

--- a/_posts/2021-08-02-config-guide.md
+++ b/_posts/2021-08-02-config-guide.md
@@ -3,7 +3,7 @@ layout: post
 title: Config Guide
 date: 2021-08-24 00:01 +0800
 last_modified_at: 2024-11-21 20:24 +0800
-category: [doc]
+categories: [doc]
 tags: [_config]
 permalink: /config-guide/
 image: 

--- a/_posts/2021-08-15-postprocessing.md
+++ b/_posts/2021-08-15-postprocessing.md
@@ -3,7 +3,7 @@ layout: post
 title: Post-Processing
 date: 2021-08-15 23:15 +0800
 last_modified_at: 2021-08-22 09:41 +0800
-category: [feature]
+categories: [feature]
 tags: [styles, demo]
 permalink: /post-processing/
 image: 

--- a/_posts/2021-08-24-plugins.md
+++ b/_posts/2021-08-24-plugins.md
@@ -3,7 +3,7 @@ layout: post
 title: Plugins and Extensions
 date: 2021-09-08 12:00 +0800
 last_modified_at: 2024-01-10 22:23 +0800
-category:
+categories:
    - doc
 tags:
    - plugin
@@ -109,7 +109,7 @@ jekyll-archives:
     - tags
   layout: archive
   permalinks: 
-    category: '/category/:name/'
+    categories: ['/category/:name/']
     tag: '/tag/:name/'
 ```
 

--- a/_posts/2024-11-05-footer-configuration.md
+++ b/_posts/2024-11-05-footer-configuration.md
@@ -2,7 +2,7 @@
 layout: post
 title: Footer Configuration
 date: 2024-11-05 16:01 +0800
-category: [doc]
+categories: [doc]
 tags: [_config]
 permalink: /footer-configuration/
 image: 

--- a/_posts/2024-11-21-google-analytics-4.md
+++ b/_posts/2024-11-21-google-analytics-4.md
@@ -3,7 +3,7 @@ layout: post
 title: Google Analytics 4 for AMP Features
 date: 2024-11-21 11:22 +0800
 last_modified_at: 2024-11-28 21:11 +0800
-category:
+categories:
   - feature
 tags:
   - analytics

--- a/_posts/2024-11-23-amp-youtube.md
+++ b/_posts/2024-11-23-amp-youtube.md
@@ -3,7 +3,7 @@ layout: post
 title: Using AMP YouTube Components
 date: 2024-11-23 21:30 +0800
 last_modified_at: 2024-12-05 10:12 +0800
-category:
+categories:
   - feature
 tags:
   - youtube

--- a/_posts/2024-11-24-vscode-front-matter.md
+++ b/_posts/2024-11-24-vscode-front-matter.md
@@ -9,7 +9,7 @@ image:
   path: /assets/images/map-3314277.svg
   width: "730"
   height: "431"
-category:
+categories:
   - doc
 tags:
   - CMS

--- a/_posts/theme-sample-posts/2018-01-11-markup-example.md
+++ b/_posts/theme-sample-posts/2018-01-11-markup-example.md
@@ -11,7 +11,7 @@
 layout: post
 title:  "Markdown Example"
 author: John
-category: sample
+categories: [sample]
 tags: [markdown]
 image: 
     path: /assets/images/6.jpg

--- a/_posts/theme-sample-posts/2018-01-12-is-intelligence-enough.md
+++ b/_posts/theme-sample-posts/2018-01-12-is-intelligence-enough.md
@@ -11,7 +11,7 @@
 layout: post
 title:  "Is Intelligence Enough"
 author: sal
-category: sample
+categories: [sample]
 image: 
     path: /assets/images/5.jpg
     height: 383

--- a/_posts/theme-sample-posts/2018-01-12-powerful-things-markdown-editor.md
+++ b/_posts/theme-sample-posts/2018-01-12-powerful-things-markdown-editor.md
@@ -11,7 +11,7 @@
 layout: post
 title:  "Powerful things you can do with the Markdown editor"
 author: sal
-category: sample
+categories: [sample]
 tags: [markdown, youtube]
 image: 
     path: /assets/images/4.jpg

--- a/_posts/theme-sample-posts/2018-01-12-red-riding.md
+++ b/_posts/theme-sample-posts/2018-01-12-red-riding.md
@@ -11,7 +11,7 @@
 layout: post-left-sidebar
 title:  "Red Riding Hood"
 author: sal
-category: sample
+categories: [sample]
 tag: [left sidebar]
 image: 
     path: /assets/images/3.jpg

--- a/_posts/theme-sample-posts/2018-01-12-tree-of-codes.md
+++ b/_posts/theme-sample-posts/2018-01-12-tree-of-codes.md
@@ -11,7 +11,7 @@
 layout: post
 title:  "Tree of Codes"
 author: sal
-category: sample
+categories: [sample]
 image:
     path: /assets/images/2.jpg
     height: 383

--- a/_posts/theme-sample-posts/2018-01-12-we-all-wait-for-summer.md
+++ b/_posts/theme-sample-posts/2018-01-12-we-all-wait-for-summer.md
@@ -10,7 +10,7 @@
 
 layout: post
 title:  "We all wait for summer"
-category: sample
+categories: [sample]
 image: 
     path: /assets/images/1.jpg
     height: 383

--- a/frontmatter.json
+++ b/frontmatter.json
@@ -120,8 +120,8 @@
           ]
         },
         {
-          "title": "Category",
-          "name": "category",
+          "title": "Categories",
+          "name": "categories",
           "type": "categories"
         },
         {


### PR DESCRIPTION
Ensure consistent naming of category keys across all posts by updating `category` to `categories`. This change improves uniformity in the frontmatter structure.