### PR TITLE
👷 ci(github-actions): run CI on Node 24.x and enable npm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [24.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -23,6 +26,11 @@ jobs:
           ruby-version: '3.3.6'
           bundler-cache: true
           cache-version: 0
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
       - name: Install node dependencies
         run: npm install
       - name: Build site


### PR DESCRIPTION
Update the GitHub Actions CI workflow to use a job matrix that runs on Node.js 24.x.

- Adds `actions/setup-node` and caches `npm` dependencies so subsequent CI runs are faster.

This ensures the theme builds with the latest Node version and improves CI performance.