### PR TITLE
⬆️ chore(deps-dev): bump nanoid to 3.3.18 for fixing CVE-2026-67213

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1173,8 +1173,8 @@ packages:
     resolution: {integrity: sha512-32GSKM3Wyc8dg/p39lWPKYu8zci9mJFzV1Np9Of0ZEpe6Fhssn/FbI7ywAMd40uX+p3ZKh3T5EeCFv81qS3HmQ==}
     engines: {node: '>= 10.13.0'}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3243,7 +3243,7 @@ snapshots:
 
   mute-stdout@2.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nice-try@1.0.5: {}
 
@@ -3590,7 +3590,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ minimumReleaseAgeExclude:
   - svgo@4.0.2
   - terser@5.14.2
   - postcss@8.4.31 || 8.5.10 || 8.5.12 || 8.5.18 || 8.5.23
+  - nanoid@3.3.17
 overrides:
   postcss@<8.4.31: ^8.4.31
   postcss@<8.5.10: ^8.5.10


### PR DESCRIPTION
- update nanoid version in lockfile
- exclude nanoid 3.3.17 in workspace config